### PR TITLE
Replaced erroneous str() conversion from bytes to str with bytes.decode

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.5.3
+^^^^^
+:release-date: unknown
+
+- Fixed wrong conversion from bytes to str for Python 3.x. str(b'') doesn't return "" but "b''". Now using bytes.decode instead.
+
 0.5.2
 ^^^^^
 :release-date: 2021-02-10

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import sys
 
 __doc__ = """Command line tool and library wrapper around '/etc/wpa_supplicant/wpa_supplicant.conf'"""
 
-version = '0.5.2'
+version = '0.5.3'
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
@@ -73,6 +73,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
     ],
     data_files=data_files
 )

--- a/wpa_pyfi/network.py
+++ b/wpa_pyfi/network.py
@@ -178,7 +178,7 @@ class Network(object):
             raise ConnectionError("An error occured during wpa_cli reconfigure %r\n\nwpa_cli Output:" + output % self)
 
     def get_connection_data(self):
-        ifconfig_output = str(subprocess.check_output(['ifconfig']))
+        ifconfig_output = subprocess.check_output(['ifconfig']).decode('utf-8')
         try:
             ifconfig_parse = IfconfigParser(console_output=ifconfig_output)
             return ifconfig_parse.get_interface(self.interface)


### PR DESCRIPTION
I was testing this library on my RPi 3 with Python 3.9 and found out that when trying to connect network interfaces are not found, because they're prepended with n (e.g. `wlan0` was `nwlan0`) because of `\n`. Root cause is wrong conversion from `bytes` to `str`.

This PR fixes that problem.